### PR TITLE
Add support for Tailwind in TypeScript

### DIFF
--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -4,7 +4,7 @@ module.exports = {
   content: [
     './public/*.html',
     './app/helpers/**/*.rb',
-    './app/javascript/**/*.{js,jsx}',
+    './app/javascript/**/*.{js,jsx,ts,tsx}',
     './app/views/**/*.{erb,haml,html,slim}',
   ],
   theme: {


### PR DESCRIPTION
~~Currently the setup for Tailwind tree-shakes CSS classes based on their usage in ERB. This makes it a smidge harder to style a Tailwind + React-flavoured solution, since certain classes won't be there in the generated stylesheet.~~

~~As a workaround, this change skips the whole tree-shaking thing by failing back to plain ol' Tailwind in an effort to give developers a chance to showcase their JSX/React skills.~~

Include Tailwind classes from `.tsx` and`.ts` files.